### PR TITLE
Elo rank

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-msedge",
+            "request": "launch",
+            "name": "Launch Edge against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+const parameters = {
+    init_score: 1500
+}
+
+module.exports = { parameters }

--- a/controllers/storms.js
+++ b/controllers/storms.js
@@ -82,19 +82,18 @@ router.post('/create', async(req, res, next) => {
                 // add topics to the request
                 req.body.ratings = topics[0]
                 console.log(req)
+                // add topics in db if new
+                let topic_titles = ml.getTopicsTitles(topics[0])
+                createTopics(topic_titles)
+                // add skill with init score to the user if the skill is a new one
+                topic_titles.forEach(t => skills.addNewSkillToUser(req.user, { topic: t, score: config.parameters.init_score }))
+                // TODO: the storm get the freezed skills of the user at the beginning (as credibility)
+
                 // create storm in db
                 let storm = await Storms.create(req.body)
                 if (storm) {
                     console.log('storm created in db')
                     console.log('id: ', storm._id)
-                    // calculate topics
-                    let topics = ml.getTopics(storm.text)
-                    // add topics in db if new
-                    let topic_titles = ml.getTopicsTitles(topics[0])
-                    createTopics(topic_titles)
-                    // add skill with init score to the user if the skill is a new one
-                    topic_titles.forEach(t => skills.addNewSkillToUser(req.user, { topic: t, score: config.parameters.init_score }))
-                    // TODO: update skill score of use
                     res.redirect('/')
                 }
 

--- a/controllers/storms.js
+++ b/controllers/storms.js
@@ -47,7 +47,7 @@ router.get('/', async(req, res, next) => {
             return s
         }))
 
-        console.log('st2: ', JSON.stringify(storms, null, 2))
+        // console.log('st2: ', JSON.stringify(storms, null, 2))
 
         // render the page
         res.render('storms/list', { user: req.user, storms })

--- a/controllers/thunders.js
+++ b/controllers/thunders.js
@@ -15,18 +15,18 @@ router.post('/create', async(req, res, next) => {
             res.redirect('auth/login')
         } else {
             console.log('\npost request: thunderize (Create a thunder)')
-                //to create a thunder the model neeeds:
-                // author, comment, trust_rate, freezed_skills, storm
+            //to create a thunder the model neeeds:
+            // author, comment, trust_rate, freezed_skills, storm
             req.body.author = req.user
-                // comment is already inside the req
-                // trust_rate is already inside the req
+            // comment is already inside the req
+            // trust_rate is already inside the req
             req.body.freezed_skills = req.user.skills
             console.log('req: ', req.body)
             let thunder = await Thunders.create(req.body)
             if (thunder) {
                 console.log('thunder created')
                 console.log('id: ', thunder._id)
-                    // redirect:
+                // redirect:
                 let request_from_user_page = false
                 if (!request_from_user_page) {
                     res.redirect('/')

--- a/controllers/thunders.js
+++ b/controllers/thunders.js
@@ -2,8 +2,11 @@
 const { query } = require('express');
 const express = require('express')
 const router = express.Router()
+// Import Models
 const Thunders = require('../models/thunders')
 const Storms = require('../models/storms')
+// Import Services 
+const skills = require('../services/skills')
 
 
 
@@ -22,7 +25,22 @@ router.post('/create', async(req, res, next) => {
             // trust_rate is already inside the req
             req.body.freezed_skills = req.user.skills
             console.log('req: ', req.body)
+            // create thunder in db
             let thunder = await Thunders.create(req.body)
+            // populate thunder with storm
+            thunder = await Thunders.findById(thunder._id).populate('storm').lean()
+            // recalculate credibility of storm topics
+
+            await skills.updateStormCredibility(thunder)
+
+            // thunder.storm.ratings.forEach(r.
+            //     setStormTopicCredibility(thunder, )
+            // )
+
+
+
+
+            console.log('thunder storm: ', thunder)
             if (thunder) {
                 console.log('thunder created')
                 console.log('id: ', thunder._id)

--- a/controllers/thunders.js
+++ b/controllers/thunders.js
@@ -31,7 +31,7 @@ router.post('/create', async(req, res, next) => {
             thunder = await Thunders.findById(thunder._id).populate('storm').lean()
             // recalculate credibility of storm topics
 
-            await skills.updateStormCredibility(thunder)
+            await skills.updateStormCredibilityAndUserSkillsScore(thunder)
 
             // thunder.storm.ratings.forEach(r.
             //     setStormTopicCredibility(thunder, )

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "connect-mongodb-session": "^2.3.1",
         "cookie-parser": "~1.4.4",
         "dotenv": "^8.2.0",
+        "elo-rank": "^1.0.4",
         "eslint-plugin-html": "^6.2.0",
         "express": "~4.16.1",
         "express-session": "^1.17.1",
@@ -684,6 +685,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "node_modules/elo-rank": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/elo-rank/-/elo-rank-1.0.4.tgz",
+      "integrity": "sha512-K1nDpqC2AzWx7EykoOnTwbci50xZPYBsfyR2Tk4h/tVnqvr6n1+8gOlWzK3pxetN5Cmx7XbPT9D0Zam2ikM6Bw=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3144,6 +3150,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elo-rank": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/elo-rank/-/elo-rank-1.0.4.tgz",
+      "integrity": "sha512-K1nDpqC2AzWx7EykoOnTwbci50xZPYBsfyR2Tk4h/tVnqvr6n1+8gOlWzK3pxetN5Cmx7XbPT9D0Zam2ikM6Bw=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "connect-mongodb-session": "^2.3.1",
     "cookie-parser": "~1.4.4",
     "dotenv": "^8.2.0",
+    "elo-rank": "^1.0.4",
     "eslint-plugin-html": "^6.2.0",
     "express": "~4.16.1",
     "express-session": "^1.17.1",

--- a/services/elo.js
+++ b/services/elo.js
@@ -1,0 +1,17 @@
+const getStormWinPoints = (thunder_player, storm_player) => {
+    //create object with K-Factor(without it defaults to 32)
+    var EloRank = require('elo-rank');
+    var elo = new EloRank(15);
+    
+    //Gets expected score for first parameter
+    var expectedScoreStorm = elo.getExpected(storm_player, thunder_player);
+    // var expectedScoreB = elo.getExpected(playerB, playerA);
+    
+    //update score, 1 if won 0 if lost
+    storm_player_updated_score = elo.updateRating(expectedScoreStorm, 1, storm_player);
+    points = storm_player_updated_score - storm_player
+    return points
+
+}
+
+module.exports = {getStormWinPoints}

--- a/services/reload.js
+++ b/services/reload.js
@@ -1,0 +1,19 @@
+const Users = require("../models/users")
+
+const loggedUser = async (req, next) => {
+    try {
+        let user = await Users.findById(req.user._id) 
+        req.login(user, (err) => {
+            if (err) {
+                throw err
+            } else {
+                return
+            }
+        })
+        
+    } catch (err) {
+        next(err)
+    }
+}
+
+module.exports = {loggedUser}

--- a/services/skills.js
+++ b/services/skills.js
@@ -1,5 +1,8 @@
 // Import Packages
 const Users = require('../models/users')
+const Storms = require('../models/storms')
+// Import Services
+const elo = require('../services/elo')
 
 const addNewSkillToUser = async(user, skill) => {
     // attribute a new skill to a user givev his id
@@ -24,7 +27,38 @@ const getTopicScore = (topics, title) => {
     // Given an array of topics:[]
     // [{topic: 'BIO', score: 1600}, {topic: 'MED', score: 1200}]
     // returns the score of the topic
-    return topics.find(t => t.topic === title).score
+    foundTopic = topics.find(t => t.topic === title)
+    if (foundTopic) {
+        return foundTopic.score
+    }
 }
 
-module.exports = { addNewSkillToUser, getTopicScore }
+const updateStormCredibility = async (thunder) => {
+    // recalculate credibility of storm topics
+    // for each topic of the storm recalculate
+    console.log('\nUpdating storm credibility:')
+    thunder.storm.ratings.forEach((r, i) => {
+        //look if the the thunder impacts this topic
+        let score = getTopicScore(thunder.freezed_skills, r.topic)
+        if (score){
+            thunder_topic_score = score
+            storm_topic_score = r.credibility
+            points = elo.getStormWinPoints(thunder_topic_score, storm_topic_score)
+            // weight point with thunder trust_rate and storm topic pertincence
+            weighted_points = points*r.pertinence/100*thunder.trust_rate/3
+            // update credibility
+            r.credibility = r.credibility + weighted_points
+            console.log('topic thunder/storm: ', r.topic)
+            console.log('thunder topic score: ', thunder_topic_score)
+            console.log('storm topic score (credibility): ', storm_topic_score)
+            console.log('points: ', points)
+            console.log('weighted points: ', weighted_points)
+            console.log('new credibility: ', r.credibility)
+        }
+    })
+    // update storm 
+    let storm = await Storms.findByIdAndUpdate(thunder.storm._id, thunder.storm, {new: true})
+    if (storm) {console.log('storm credibility updated')}
+}
+
+module.exports = { addNewSkillToUser, getTopicScore, updateStormCredibility }

--- a/services/skills.js
+++ b/services/skills.js
@@ -5,12 +5,11 @@ const Storms = require('../models/storms')
 const elo = require('../services/elo')
 
 const addNewSkillToUser = async(user, skill) => {
-    // attribute a new skill to a user givev his id
+    // attribute a new skill to a given user
     // the skill object is like: {topic: 'bio', score: '10'}
-    console.log('\nUpdating user skill')
-    console.log('user: ', user.name)
+    console.log('\nCreating new user skill')
+    console.log('user: ', user.email)
     console.log('skill: ', skill)
-
 
     let matchSkill = user.skills.find(s => s.topic == skill.topic)
     console.log('matchSkill: ', matchSkill)
@@ -23,6 +22,61 @@ const addNewSkillToUser = async(user, skill) => {
     }
 }
 
+const updateUserSkillScore = (user, topic, score_variation) => {
+    // attribute a new skill to a given user
+    // the skill object is like: {topic: 'bio', score: '10'}
+    console.log('\nUpdating user skill')
+    console.log('user: ', user.email)
+    console.log('skill: ', topic)
+    console.log('score variation:', score_variation)
+    // find the skill
+    let matchSkill = user.skills.find(s => s.topic == topic)
+    let topic_index = getTopicIndex(user.skills, topic)
+    console.log('index: ', topic_index)
+    if (topic_index) {
+        console.log('\nskill found, now update')
+        // variate user skill score
+        user.topics = variateTopicsScore(user.skills, topic, score_variation)
+        // return user
+    } else {
+        console.log('user doesn not have this skill')
+    }
+    return user
+}
+const updateTopicsScore = (topics, title, score) => {
+    // Given an array of topics:[]
+    // [{topic: 'BIO', score: 1600}, {topic: 'MED', score: 1200}]
+    // the title of the topic and the new score 
+    // it updtates the score returning the array of topics
+    index = getTopicIndex(topics, title)
+    topics[index].score = score
+    return topics
+}
+
+const variateTopicsScore = (topics, title, score_variation) => {
+    // Given an array of topics:[]
+    // [{topic: 'BIO', score: 1600}, {topic: 'MED', score: 1200}]
+    // the title of the topic and the new score 
+    // it updtates the score returning the array of topics
+    index = getTopicIndex(topics, title)
+    console.log('%s -> %s', topics[index].score, topics[index].score + score_variation)
+    topics[index].score += score_variation
+    return topics
+}
+
+const getTopicIndex = (topics, title) => {
+    // Given an array of topics:[]
+    // [{topic: 'BIO', score: 1600}, {topic: 'MED', score: 1200}]
+    // returns the index of the title 
+    let i = 0
+    let j
+    while (typeof j === 'undefined') {
+        if (topics[i].topic == title) {j = i}
+        i++
+    }
+    return j
+}
+
 const getTopicScore = (topics, title) => {
     // Given an array of topics:[]
     // [{topic: 'BIO', score: 1600}, {topic: 'MED', score: 1200}]
@@ -33,10 +87,12 @@ const getTopicScore = (topics, title) => {
     }
 }
 
-const updateStormCredibility = async (thunder) => {
+const updateStormCredibilityAndUserSkillsScore = async (thunder) => {
+    console.log('\nUpdating storm credibility:')
+    let storm_author = await Users.findById(thunder.storm.author._id).lean()
+    console.log('storm author: ', storm_author.email)
     // recalculate credibility of storm topics
     // for each topic of the storm recalculate
-    console.log('\nUpdating storm credibility:')
     thunder.storm.ratings.forEach((r, i) => {
         //look if the the thunder impacts this topic
         let score = getTopicScore(thunder.freezed_skills, r.topic)
@@ -54,11 +110,18 @@ const updateStormCredibility = async (thunder) => {
             console.log('points: ', points)
             console.log('weighted points: ', weighted_points)
             console.log('new credibility: ', r.credibility)
+            // update storm author skill score
+            storm_author = updateUserSkillScore(storm_author, r.topic, weighted_points)
         }
     })
-    // update storm 
+    // update storm in db (topics credibility)
     let storm = await Storms.findByIdAndUpdate(thunder.storm._id, thunder.storm, {new: true})
-    if (storm) {console.log('storm credibility updated')}
+    if (storm) {console.log('storm topics credibility updated')}
+    // update user in db (skills score)
+    let updated_storm_author = await Users.findByIdAndUpdate(storm_author._id, storm_author, {new: true} )
+    if (updated_storm_author) {console.log('user skills score updated')}
+    
 }
 
-module.exports = { addNewSkillToUser, getTopicScore, updateStormCredibility }
+
+module.exports = { addNewSkillToUser, getTopicScore, updateStormCredibilityAndUserSkillsScore, updateUserSkillScore }

--- a/services/skills.js
+++ b/services/skills.js
@@ -19,4 +19,12 @@ const addNewSkillToUser = async(user, skill) => {
         console.log('user has already this skill')
     }
 }
-module.exports = { addNewSkillToUser }
+
+const getTopicScore = (topics, title) => {
+    // Given an array of topics:[]
+    // [{topic: 'BIO', score: 1600}, {topic: 'MED', score: 1200}]
+    // returns the score of the topic
+    return topics.find(t => t.topic === title).score
+}
+
+module.exports = { addNewSkillToUser, getTopicScore }

--- a/todo.txt
+++ b/todo.txt
@@ -11,6 +11,8 @@
     here the calculations of points per topic (player1 is the one who launch the thunder, player2 the author of the storm):
     - elo.player2win / 3 * score * topic_pertinence
 4-done) the points are given to the storm correspondent topic 
-5) and to the author
+5-done) and to the author
 6) when the topics scores are stablizied the thunder author can loose points if he voted in the wrong way
 7) salvare skills and scors nella blockchain?
+8) thunderize only when comment, only when rate
+9) if comment yourself thunder rate always at zero

--- a/todo.txt
+++ b/todo.txt
@@ -7,9 +7,10 @@
 ---------------------------
 1-done) when a user create a storms acquires 1500 per each topic if new
 2-done) the storm get the freezed skills of the user at the beginning (as credibility)
-3) every time a user create a thunder there is a Elo match:
-    - here the calculations of points per topic:
+3-done) every time a user create a thunder there is a Elo match:
+    here the calculations of points per topic (player1 is the one who launch the thunder, player2 the author of the storm):
     - elo.player2win / 3 * score * topic_pertinence
-4) the points are given to the storm correspondent topic and to the author
-5) when the topics scores are stablizied the thunder author can loose points if he voted in the wrong way
-6) salvare skills and scors nella blockchain?
+4-done) the points are given to the storm correspondent topic 
+5) and to the author
+6) when the topics scores are stablizied the thunder author can loose points if he voted in the wrong way
+7) salvare skills and scors nella blockchain?

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,14 @@
+###################################
+#   TODO LIST / REQUIREMENTS      #
+###################################
+
+---------------------------
+-   points attribution:   -
+---------------------------
+1) when a user create a storms acquires 1500 per each topic
+2) the storm get the freezed skills of the user at the beginning 
+3) every time a user create a thunder there is a Elo match:
+    - here the calculations of points per topic:
+    - elo.player2win / 3 * score * topic_pertinence
+4) the points are given to the storm correspondent topic and to the author
+5) when the topics scores are stablizied the thunder author can loose points if he voted in the wrong way

--- a/todo.txt
+++ b/todo.txt
@@ -5,10 +5,11 @@
 ---------------------------
 -   points attribution:   -
 ---------------------------
-1) when a user create a storms acquires 1500 per each topic
+1-done) when a user create a storms acquires 1500 per each topic if new
 2) the storm get the freezed skills of the user at the beginning 
 3) every time a user create a thunder there is a Elo match:
     - here the calculations of points per topic:
     - elo.player2win / 3 * score * topic_pertinence
 4) the points are given to the storm correspondent topic and to the author
 5) when the topics scores are stablizied the thunder author can loose points if he voted in the wrong way
+6) salvare skills and scors nella blockchain?

--- a/todo.txt
+++ b/todo.txt
@@ -6,7 +6,7 @@
 -   points attribution:   -
 ---------------------------
 1-done) when a user create a storms acquires 1500 per each topic if new
-2) the storm get the freezed skills of the user at the beginning 
+2-done) the storm get the freezed skills of the user at the beginning (as credibility)
 3) every time a user create a thunder there is a Elo match:
     - here the calculations of points per topic:
     - elo.player2win / 3 * score * topic_pertinence

--- a/views/partials/thunderize.hbs
+++ b/views/partials/thunderize.hbs
@@ -10,9 +10,9 @@
 	<div class="slidecontainer">
 		<input
 			type="range"
-			min="1"
-			max="7"
-			value="4"
+			min="-3"
+			max="3"
+			value="0"
 			class="slider"
 			id="myRange"
 			name="trust_rate"


### PR DESCRIPTION
--------------------------
-   points attribution:        -
--------------------------
- [x] when a user create a storms acquires 1500 per each topic if new
- [x] the storm get the freezed skills of the user at the beginning (as credibility)
- [x] every time a user create a thunder there is a Elo match:
    here the calculations of points per topic (player1 is the one who launch the thunder, player2 the author of the storm):
    - elo.player2win / 3 * score * topic_pertinence
- [x] the points are given to the storm correspondent topic 
- [x] and to the author
- [ ] when the topics scores are stablizied the thunder author can loose points if he voted in the wrong way
- [ ] salvare skills and scors nella blockchain?
- [ ] thunderize only when comment, only when rate
- [ ] if comment yourself thunder rate always at zero